### PR TITLE
Removed not necessary debug instruction

### DIFF
--- a/fast_deilabs.sh
+++ b/fast_deilabs.sh
@@ -151,7 +151,6 @@ function exit_lab {
 						   --save-cookies ${cookies_file} \
 						   --post-data "_token=${token}&_method=PUT" \
 						   -O - "$exit_url" 2> /dev/null)
-	echo "$enter_lab_result" > bubu
 	if ! [[ -z $(echo "$exit_lab_result" | grep "OK") ]]; then
 		echo "Successfully exited"
 	else


### PR DESCRIPTION
echo "$enter_lab_result" > bubu
was probably meant as debug instruction during development but now it only creates a file named bubu in the same folder from where the user calls the command.